### PR TITLE
Splash re-routing. Resume game modal. Quote last hole

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,9 @@
   <div id="app" class="antialiased h-screen">
     <div></div>
     <transition name="fade" mode="out-in">
-      <component :is="isTimeout" @clear="clearTimeout"></component>
+      <Timeout v-if="isTimeout"
+        >Looks like you've been away for a while...</Timeout
+      >
     </transition>
     <transition name="fade" mode="out-in">
       <component :is="this.$route.meta.layout || 'div'">
@@ -18,19 +20,19 @@ export default {
   components: { Timeout },
   data() {
     return {
-      isTimeout: ''
+      isTimeout: false
     };
   },
   provide() {
     return {
-      timeout: this.clearTimeout
+      Timeout: this.clearTimeout
     };
   },
   methods: {
     clearTimeout() {
-      this.isTimeout = '';
+      this.isTimeout = false;
       setTimeout(() => {
-        this.isTimeout = Timeout;
+        this.isTimeout = true;
       }, 600000); // 10 minutes
     }
   }

--- a/src/components/Timeout.vue
+++ b/src/components/Timeout.vue
@@ -2,7 +2,7 @@
   <div class="z-50">
     <ModalLayout @close="next('close')">
       <h1 class="uppercase text-aeb49a text-xl text-center font-kalam px-5">
-        Looks like you've been away for a while...
+        <slot></slot>
       </h1>
 
       <div class="w-4/5 mx-auto">

--- a/src/components/utilities/BaseButton.vue
+++ b/src/components/utilities/BaseButton.vue
@@ -12,7 +12,7 @@
 
 <script>
 export default {
-  inject: ['timeout'],
+  inject: ['Timeout'],
   props: {
     mode: {
       type: String
@@ -23,7 +23,7 @@ export default {
   },
   methods: {
     clicked() {
-      this.timeout();
+      this.Timeout();
       this.$emit('clicked');
     }
   },

--- a/src/views/CurrentTotal.vue
+++ b/src/views/CurrentTotal.vue
@@ -72,7 +72,7 @@
     <!-- Button -->
     <div class="flex-1 flex items-center h-1/4">
       <base-button
-     :to="{ name: 'NewHole', params: { holeNo: holeNo } }"
+        :to="{ name: 'NewHole', params: { holeNo: holeNo } }"
         mode="btn confirm"
       >
         {{ holeNo != 14 ? 'on to the next hole!' : 'Award ceremony' }}
@@ -160,7 +160,7 @@ export default {
     ...mapActions('gameInfo', ['getGameDetails', 'increaseCounter'])
   },
   beforeRouteLeave(to, from, next) {
-    if (to.params.holeNo === 14) {
+    if (to.params.holeNo === this.getPar.length) {
       return next({ name: 'Awards' });
     }
     to.params.holeNo = to.params.holeNo + 1;

--- a/src/views/GameCourse.vue
+++ b/src/views/GameCourse.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="md:w-1/3 md:mx-auto">
+    <NewGame v-if="startNewGame" @clear="startNewGame = false"
+      >Welcome back!</NewGame
+    >
     <div class="grid grid-cols-3 gap-0" v-if="courseGrid">
       <div v-for="(square, index) in courseGrid.squareInfo" :key="square.id">
         <img
@@ -29,12 +32,14 @@
 <script>
 import axios from 'axios';
 import { mapActions } from 'vuex';
+import NewGame from '@/components/Timeout.vue';
 
 export default {
   name: 'GameCourse',
   data() {
     return {
-      courseGrid: {}
+      courseGrid: {},
+      startNewGame: false
     };
   },
   created() {
@@ -49,8 +54,11 @@ export default {
         .catch(e => console.log(e));
     } else {
       this.courseGrid = JSON.parse(localStorage.getItem('course-grid'));
+      this.updatePar();
+      this.startNewGame = this.$route.params.startNewGame;
     }
   },
+  components: { NewGame },
   methods: {
     ...mapActions('gameInfo', ['updatePar']),
     gotoNewHole(holeNo) {

--- a/src/views/NewHole.vue
+++ b/src/views/NewHole.vue
@@ -1,9 +1,15 @@
 <template>
   <div
-    class="md:w-1/2 bg-no-repeat bg-cover bg-center grid grid-rows-2 justify-items-center 
-    place-items-center relative"
+    class="md:w-1/2 bg-no-repeat bg-cover bg-center grid grid-rows-3 relative"
     :class="[holeBg]"
   >
+    <div v-if="holeNo === getPar.length">
+      <p
+        class="px-12 pt-8 font-capriola mt-4 mb-16 text-center text-white text-xl"
+      >
+        {{ lastPlace }}, this is your last chance to catch up!
+      </p>
+    </div>
     <div v-if="getPar.length != holeNo">
       <p class="font-kalam holeno text-white">
         {{ holeNo }}
@@ -15,6 +21,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
+import { orderBy } from 'lodash';
 export default {
   name: 'NewHole',
   props: {
@@ -36,18 +43,25 @@ export default {
     };
   },
   computed: {
-    ...mapGetters('gameInfo', ['getPar']),
+    ...mapGetters('gameInfo', ['getGameInfo', 'getPar']),
     holeBg() {
-      if (this.holeNo !== 14) {
+      if (this.holeNo !== this.getPar.length) {
         return 'bg-newHole';
       } else {
         return 'bg-lastHole';
       }
+    },
+    lastPlace() {
+      return orderBy(this.getGameInfo.playersInfo, ['totalScore'], ['desc'])[0]
+        .name;
     }
   },
   created() {
     this.courseGrid = JSON.parse(localStorage.getItem('course-grid'));
     this.updateHoleStatus();
+    let last = this.getGameInfo.playersInfo;
+
+    console.log(last);
   },
   methods: {
     updateHoleStatus() {

--- a/src/views/NewHole.vue
+++ b/src/views/NewHole.vue
@@ -7,7 +7,12 @@
       <p
         class="px-12 pt-8 font-capriola mt-4 mb-16 text-center text-white text-xl"
       >
-        {{ lastPlace }}, this is your last chance to catch up!
+        {{ lastPlace }},
+        {{
+          getGameInfo.playersInfo.length !== 1
+            ? 'this is your last chance to catch up!'
+            : "you're almost there!"
+        }}
       </p>
     </div>
     <div v-if="getPar.length != holeNo">

--- a/src/views/NewHole.vue
+++ b/src/views/NewHole.vue
@@ -59,9 +59,6 @@ export default {
   created() {
     this.courseGrid = JSON.parse(localStorage.getItem('course-grid'));
     this.updateHoleStatus();
-    let last = this.getGameInfo.playersInfo;
-
-    console.log(last);
   },
   methods: {
     updateHoleStatus() {

--- a/src/views/Splash.vue
+++ b/src/views/Splash.vue
@@ -34,7 +34,7 @@ export default {
         .catch(e => console.log(e));
     }
     setTimeout(() => {
-      if (!localStorage.getItem('course-grid')) {
+      if (!localStorage.getItem('course-grid') && gameId) {
         return this.$router.push({ name: 'SelectPlayers' });
       } else if (localStorage.getItem('course-grid')) {
         return this.$router.push({

--- a/src/views/Splash.vue
+++ b/src/views/Splash.vue
@@ -34,7 +34,14 @@ export default {
         .catch(e => console.log(e));
     }
     setTimeout(() => {
-      return this.$router.push({ name: 'SelectPlayers' });
+      if (!localStorage.getItem('course-grid')) {
+        return this.$router.push({ name: 'SelectPlayers' });
+      } else if (localStorage.getItem('course-grid')) {
+        return this.$router.push({
+          name: 'GameCourse',
+          params: { startNewGame: true }
+        });
+      }
     }, 2000);
   }
 };


### PR DESCRIPTION
# Issue Being Addressed
#39 
Put the issue(s) # that your PR is addressing here. e.g. #15, #29

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[ ] Refactor
[x] New Feature
[ ] Update to Existing Feature
[ ] Other (state below)

# Description

**For Bug Fixes:** What was the root cause? How do your changes fix the bug effectively?
Game not always loading from splash screen, so corrected it to check if there is data in storage. If already, router can push.


**For New Features:** What feature are we adding? Explain your technical approach to doing this.
Added a Resume Game modal if there is already game info in the local storage. In this case, instead of splash routing to players-select screen, it takes you to the course grid and the Resume Game modal appears. You can resume or start a new game here.

Have also addressed the last screen badge from issue #39. The player in last position is named with a quote following, prompting them to catch up.



# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.
1. Log in as '...'
2. Go to '...'
3. Click on '...'
4. See the updated element x

# Screenshots/casts

If applicable, include any relevant screenshot or screencasts of your changes.

# Additional Context

Provide any additional notes that you think would help effective review of your code.