### PR TITLE
players inputs now load first time

### DIFF
--- a/src/views/NamePlayers.vue
+++ b/src/views/NamePlayers.vue
@@ -57,10 +57,9 @@ export default {
     ...mapGetters('gameInfo', ['getGameInfo'])
   },
   created() {
+    this.inputs = this.$route.params.noOfPlayers;
     this.getGameDetails()
-      .then(() => {
-        this.inputs = this.getGameInfo.noOfPlayers;
-      })
+      .then(() => {})
       .catch(e => console.log(e));
   },
   methods: {

--- a/src/views/SelectPlayers.vue
+++ b/src/views/SelectPlayers.vue
@@ -48,7 +48,12 @@ export default {
         noOfPlayers: this.noOfPlayers
       };
       this.updateGameDetails(payload)
-        .then(this.$router.push({ name: 'NamePlayers' }))
+        .then(
+          this.$router.push({
+            name: 'NamePlayers',
+            params: { noOfPlayers: this.noOfPlayers }
+          })
+        )
         .catch(e => console.log(e));
     }
   }


### PR DESCRIPTION
# Issue Being Addressed
Not a noted issue. Players name inputs were not loading first time (you'd need to refresh the screen). I have updated the inputs to be based on the router params rather than waiting for local storage to retrieve it, which seemed to be causing the issue.

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

[x] Bug Fix
[x] Refactor