### PR TITLE
changed bg on lasthole screen and fixed player score

### DIFF
--- a/src/views/CurrentTotal.vue
+++ b/src/views/CurrentTotal.vue
@@ -37,7 +37,7 @@
               class="flex items-center justify-center h-8 w-8 border border-white rounded-full text-white mr-2"
             >
               <p class="mt-1">
-                {{ getHighestTotalPlayer.totalScore }}
+                {{ getHighestTotalPlayer.holeScore[holeNo - 1] }}
               </p>
             </div>
             <div class="h-8 w-8 rounded-full text-center bg-ff8e67 text-white">

--- a/src/views/GameCourse.vue
+++ b/src/views/GameCourse.vue
@@ -82,6 +82,7 @@ export default {
       players.forEach(el => {
         el.holeScore = courseHoles;
       });
+      console.log(courseHoles);
     }
   },
   computed: {

--- a/src/views/GameCourse.vue
+++ b/src/views/GameCourse.vue
@@ -82,7 +82,6 @@ export default {
       players.forEach(el => {
         el.holeScore = courseHoles;
       });
-      console.log(courseHoles);
     }
   },
   computed: {

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-wait bg-center bg-cover bg-no-repeat bg-red-500 grid grid-rows-2 px-16 h-screen"
+    class="bg-wait bg-center bg-cover bg-no-repeat bg-fff6eb grid grid-rows-2 px-16 h-screen"
   >
     <div class="h-full"></div>
     <div class="h-full text-center text-005d63">


### PR DESCRIPTION
Last hole had red bg so it would show on load. Fixed to same bg colour as the bg-image.
1st place player score was showing the total score in both circles, in place of where the "last score" should be. Updated that to be correct.