### PR TITLE
age-input-field

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,11 @@
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="theme-color" content="#fff4e7" />
     <!-- End Favicons -->
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Capriola&display=swap"
+      rel="stylesheet"
+    />
     <script src="https://unpkg.com/vue-meta/dist/vue-meta.min.js"></script>
   </head>
   <body>

--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <select
-    class="text-3b9d11 border border-f5e3c8 rounded-full focus:outline-none relative pl-3 font-capriola text-3B9D11"
+    class="text-3b9d11 border border-f5e3c8 rounded-full focus:outline-none relative px-2 font-capriola text-3B9D11"
     :class="{ error: isInvalid }"
     :value="value"
     required
@@ -33,5 +33,7 @@ select,
 option {
   -webkit-appearance: none;
   color: #78d03a;
+  text-align-last: center;
+  font-family: 'Capriola', sans-serif;
 }
 </style>


### PR DESCRIPTION
#117 
Not sure what you had in mind for this, but I did manage to center the text in both FF and Chrome. Updated the font-family to be Capriola in FF also. I had to add a <link> in index.html to reach out to Google Fonts for that though as it wasn't reading it via Tailwind.

Cannot remove the options border, round the edges or remove the focus state in FF, forums suggest these are not possible to do. 