### PR TITLE
timeout modal moved and fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vue-router": "^3.2.0",
     "vue-slider-component": "^3.2.11",
     "vue-star-rating": "^1.7.0",
+    "vue2-touch-events": "^3.1.1",
     "vuex": "^3.4.0"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,42 +2,12 @@
   <div id="app" class="antialiased h-screen">
     <div></div>
     <transition name="fade" mode="out-in">
-      <Timeout v-if="isTimeout"
-        >Looks like you've been away for a while...</Timeout
-      >
-    </transition>
-    <transition name="fade" mode="out-in">
       <component :is="this.$route.meta.layout || 'div'">
         <router-view />
       </component>
     </transition>
   </div>
 </template>
-
-<script>
-import Timeout from '@/components/Timeout.vue';
-export default {
-  components: { Timeout },
-  data() {
-    return {
-      isTimeout: false
-    };
-  },
-  provide() {
-    return {
-      Timeout: this.clearTimeout
-    };
-  },
-  methods: {
-    clearTimeout() {
-      this.isTimeout = false;
-      setTimeout(() => {
-        this.isTimeout = true;
-      }, 600000); // 10 minutes
-    }
-  }
-};
-</script>
 
 <style>
 html,

--- a/src/App.vue
+++ b/src/App.vue
@@ -6,8 +6,34 @@
         <router-view />
       </component>
     </transition>
+    <transition name="fade">
+      <Timeout v-if="isTimeout" @clear="clearTimeout"></Timeout>
+    </transition>
   </div>
 </template>
+
+<script>
+import Timeout from '@/components/Timeout.vue';
+export default {
+  data() {
+    return {
+      isTimeout: false
+    };
+  },
+  components: { Timeout },
+  created() {
+    this.clearTimeout();
+  },
+  methods: {
+    clearTimeout() {
+      this.isTimeout = false;
+      setTimeout(() => {
+        this.isTimeout = true;
+      }, 600000); // 10 minutes
+    }
+  }
+};
+</script>
 
 <style>
 html,

--- a/src/components/Timeout.vue
+++ b/src/components/Timeout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="z-50">
+  <div class="z-50 absolute top-0 left-0 right-0 bottom-0">
     <ModalLayout @close="next('close')" :closingButton="false">
       <div class="py-6">
         <h1 class="uppercase text-aeb49a text-xl text-center font-kalam px-5">

--- a/src/components/utilities/BaseButton.vue
+++ b/src/components/utilities/BaseButton.vue
@@ -3,7 +3,7 @@
     :is="type"
     class="font-capriola text-white text-center focus:outline-none mx-auto block"
     :class="mode"
-    @click="clicked"
+    @click="$emit('clicked')"
     :to="to"
   >
     <slot></slot>
@@ -12,7 +12,6 @@
 
 <script>
 export default {
-  inject: ['Timeout'],
   props: {
     mode: {
       type: String
@@ -21,12 +20,7 @@ export default {
       type: [String, Object]
     }
   },
-  methods: {
-    clicked() {
-      this.Timeout();
-      this.$emit('clicked');
-    }
-  },
+
   computed: {
     type() {
       if (this.to) {

--- a/src/layouts/BottomNavLayout.vue
+++ b/src/layouts/BottomNavLayout.vue
@@ -15,9 +15,6 @@
         <RulesScreen @close-drawer="isDrawerOpen = false" />
       </div>
     </transition>
-    <transition name="fade">
-      <Timeout v-if="isTimeout" @clear="clearTimeout"></Timeout>
-    </transition>
   </div>
 </template>
 
@@ -25,32 +22,22 @@
 import NavMenu from '@/components/NavMenu';
 import RulesScreen from '@/components/rules/RulesScreen.vue';
 import vClickOutside from 'v-click-outside';
-import Timeout from '@/components/Timeout.vue';
 
 export default {
   name: 'BottomNavLayout',
-  components: { NavMenu, RulesScreen, Timeout },
+  components: { NavMenu, RulesScreen },
   directives: {
     clickOutside: vClickOutside.directive
   },
   data() {
     return {
-      isDrawerOpen: false,
-      isTimeout: false
+      isDrawerOpen: false
     };
   },
-  created() {
-    this.clearTimeout();
-  },
+
   methods: {
     onClickOutside() {
       this.isDrawerOpen = false;
-    },
-    clearTimeout() {
-      this.isTimeout = false;
-      setTimeout(() => {
-        this.isTimeout = true;
-      }, 600000); // 10 minutes
     }
   }
 };

--- a/src/layouts/BottomNavLayout.vue
+++ b/src/layouts/BottomNavLayout.vue
@@ -15,6 +15,9 @@
         <RulesScreen @close-drawer="isDrawerOpen = false" />
       </div>
     </transition>
+    <transition name="fade">
+      <Timeout v-if="isTimeout" @clear="clearTimeout"></Timeout>
+    </transition>
   </div>
 </template>
 
@@ -22,21 +25,32 @@
 import NavMenu from '@/components/NavMenu';
 import RulesScreen from '@/components/rules/RulesScreen.vue';
 import vClickOutside from 'v-click-outside';
+import Timeout from '@/components/Timeout.vue';
 
 export default {
   name: 'BottomNavLayout',
-  components: { NavMenu, RulesScreen },
+  components: { NavMenu, RulesScreen, Timeout },
   directives: {
     clickOutside: vClickOutside.directive
   },
   data() {
     return {
-      isDrawerOpen: false
+      isDrawerOpen: false,
+      isTimeout: false
     };
+  },
+  created() {
+    this.clearTimeout();
   },
   methods: {
     onClickOutside() {
       this.isDrawerOpen = false;
+    },
+    clearTimeout() {
+      this.isTimeout = false;
+      setTimeout(() => {
+        this.isTimeout = true;
+      }, 600000); // 10 minutes
     }
   }
 };

--- a/src/layouts/FullScreenLayout.vue
+++ b/src/layouts/FullScreenLayout.vue
@@ -3,31 +3,5 @@
     <transition name="fade" mode="out-in">
       <router-view class="w-full mx-auto box-border min-h-screen" />
     </transition>
-    <transition name="fade">
-      <Timeout v-if="isTimeout" @clear="clearTimeout"></Timeout>
-    </transition>
   </div>
 </template>
-
-<script>
-import Timeout from '@/components/Timeout.vue';
-export default {
-  data() {
-    return {
-      isTimeout: false
-    };
-  },
-  components: { Timeout },
-  created() {
-    this.clearTimeout();
-  },
-  methods: {
-    clearTimeout() {
-      this.isTimeout = false;
-      setTimeout(() => {
-        this.isTimeout = true;
-      }, 600000); // 10 minutes
-    }
-  }
-};
-</script>

--- a/src/layouts/FullScreenLayout.vue
+++ b/src/layouts/FullScreenLayout.vue
@@ -3,5 +3,31 @@
     <transition name="fade" mode="out-in">
       <router-view class="w-full mx-auto box-border min-h-screen" />
     </transition>
+    <transition name="fade">
+      <Timeout v-if="isTimeout" @clear="clearTimeout"></Timeout>
+    </transition>
   </div>
 </template>
+
+<script>
+import Timeout from '@/components/Timeout.vue';
+export default {
+  data() {
+    return {
+      isTimeout: false
+    };
+  },
+  components: { Timeout },
+  created() {
+    this.clearTimeout();
+  },
+  methods: {
+    clearTimeout() {
+      this.isTimeout = false;
+      setTimeout(() => {
+        this.isTimeout = true;
+      }, 600000); // 10 minutes
+    }
+  }
+};
+</script>

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ import vClickOutside from 'v-click-outside';
 import router from './router';
 import store from './store';
 import VueClipboard from 'vue-clipboard2';
+import Vue2TouchEvents from 'vue2-touch-events';
 
 Vue.config.productionTip = false;
 
@@ -19,6 +20,7 @@ Vue.use(VueMeta, {
 });
 
 Vue.use(VueClipboard);
+Vue.use(Vue2TouchEvents);
 
 Vue.use(VueGtm, {
   id: ['GTM-59PVXGQ'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -9097,6 +9097,11 @@ vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
+vue2-touch-events@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/vue2-touch-events/-/vue2-touch-events-3.1.1.tgz#8d3db2e89c98ea2500850da507e2c9a4247088f6"
+  integrity sha512-u8LqHrcd9foOrHmPEZuxWwPDHD1xdRjT7zPVb0jL3yA9XT7RUAtKGg+Cb/T4UjtgCvUShBgIKrORiMY33/RkGg==
+
 vue@^2.3.3, vue@^2.6.11:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"


### PR DESCRIPTION
No issue number
Timeout modal was not functioning correctly. I've moved it away from App.vue and into the 2 separate layout files. It now works much better.

I also installed vue2-touch-events to try to implement a slide-close directive for the rules display. Will look at that in another branch and PR though.