### PR TITLE
last hole working with conditional routes

### DIFF
--- a/src/views/GameCourse.vue
+++ b/src/views/GameCourse.vue
@@ -34,7 +34,8 @@ export default {
   name: 'GameCourse',
   data() {
     return {
-      courseGrid: {}
+      courseGrid: {},
+      playersInfo: []
     };
   },
   created() {
@@ -59,13 +60,46 @@ export default {
     }, 500);
   },
   methods: {
-    ...mapActions('gameInfo', ['updatePar']),
+    ...mapActions('gameInfo', ['updatePar', 'getGameDetails']),
+
     gotoHole(holeNo, mode) {
-      this.$router.push({
-        name: this.getPar.length === holeNo ? 'LastHoleWarning' : 'NewHole',
-        params: { holeNo: holeNo, mode: mode }
-      });
+      if (holeNo !== this.getPar.length) {
+        this.$router.push({
+          name: 'NewHole',
+          params: { holeNo: holeNo, mode: mode }
+        });
+      } else {
+        this.getGameDetails()
+          .then(response => {
+            this.playersInfo = response.playersInfo;
+            if (this.playersInfo) {
+              let unfinishedHoles = [];
+              this.playersInfo[0].holeScore.forEach((el, index) => {
+                if (el === 0) {
+                  unfinishedHoles.push(index + 1);
+                }
+              });
+              if (unfinishedHoles.length > 1) {
+                this.$router.push({
+                  name: 'LastHoleWarning',
+                  params: {
+                    holeNo: holeNo,
+                    mode: mode,
+                    unfinishedHoles: unfinishedHoles
+                  }
+                });
+              } else {
+                this.$router.push({
+                  name: 'NewHole',
+                  params: { holeNo: holeNo, mode: mode }
+                });
+              }
+            }
+          })
+          .catch(e => console.log(e));
+      }
     },
+
     createPlayerScores() {
       let courseHoles = [];
       let holes = this.courseGrid.numberOfHoles;

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -60,10 +60,15 @@ export default {
   computed: {
     ...mapGetters('gameInfo', ['getPar']),
     unfinishedHoles() {
-      let unfinishedHole = this.$route.params.unfinishedHoles;
-      unfinishedHole.splice(-1, 1);
-      unfinishedHole.splice(-1, 0, 'and');
-      return unfinishedHole.join(', ');
+      let unfinishedHoles = [];
+      this.playersInfo[0].holeScore.forEach((el, index) => {
+        if (el === 0) {
+          unfinishedHoles.push(index + 1);
+        }
+      });
+      unfinishedHoles.splice(-1, 1);
+      unfinishedHoles.splice(-1, 0, 'and');
+      return unfinishedHoles.join(', ');
     }
   }
 };

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -10,7 +10,7 @@
       <div v-if="playersInfo.length" class="font-capriola mt-4">
         <p>
           It seems you haven't played
-          {{ unfinishedHoles.length > 2 ? 'holes No' : 'hole No' }}
+          {{ unfinishedHoles.length > 2 ? 'holes:' : 'hole:' }}
           <span class="text-ff6350"> {{ unfinishedHoles }}</span>
         </p>
         <p class="mt-2">What do you want to do about it?</p>

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -68,7 +68,7 @@ export default {
       });
       unfinishedHoles.splice(-1, 1);
       unfinishedHoles.splice(-1, 0, 'and');
-      return unfinishedHoles.join(', ');
+      return unfinishedHoles.join(' ');
     }
   }
 };

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -9,7 +9,8 @@
       </p>
       <div v-if="playersInfo.length" class="font-capriola mt-4">
         <p>
-          It seems you haven't played holes No
+          It seems you haven't played
+          {{ unfinishedHoles.length > 2 ? 'holes No' : 'hole No' }}
           <span class="text-ff6350"> {{ unfinishedHoles }}</span>
         </p>
         <p class="mt-2">What do you want to do about it?</p>
@@ -66,9 +67,15 @@ export default {
           unfinishedHoles.push(index + 1);
         }
       });
-      unfinishedHoles.splice(-1, 1);
-      unfinishedHoles.splice(-1, 0, 'and');
-      return unfinishedHoles.join(' ');
+      if (unfinishedHoles.length > 2) {
+        unfinishedHoles.splice(-1, 1);
+        unfinishedHoles.splice(-1, 0, 'and');
+        return unfinishedHoles.join(' ');
+      } else {
+        unfinishedHoles.splice(-1, 1);
+        unfinishedHoles.splice(-1, 0);
+        return unfinishedHoles.join(' ');
+      }
     }
   }
 };

--- a/src/views/LastHoleWarning.vue
+++ b/src/views/LastHoleWarning.vue
@@ -23,7 +23,10 @@
           Tackle it now
         </BaseButton>
         <BaseButton
-          :to="{ name: 'NewHole', params: { holeNo: this.getPar.length } }"
+          :to="{
+            name: 'NewHole',
+            params: { holeNo: this.getPar.length, mode: 'new' }
+          }"
           mode="btn secondary-blue"
         >
           Finish anyway
@@ -57,12 +60,7 @@ export default {
   computed: {
     ...mapGetters('gameInfo', ['getPar']),
     unfinishedHoles() {
-      let unfinishedHole = [];
-      this.playersInfo[0].holeScore.forEach((el, index) => {
-        if (el === 0) {
-          unfinishedHole.push(index + 1);
-        }
-      });
+      let unfinishedHole = this.$route.params.unfinishedHoles;
       unfinishedHole.splice(-1, 1);
       unfinishedHole.splice(-1, 0, 'and');
       return unfinishedHole.join(', ');


### PR DESCRIPTION
No issue listed.
Issue completed.
I've added 3 conditionals that will determine the route of the last hole when it is clicked on.

Test: If the user selects a hole that isn't the last hole, route to new hole as normal.
Test: If there are other holes to play, the last hole warning will show up.
Test: If there are no other holes to play, the route will deliver the new-hole screen.

Bug fix: Added "mode: new" to the params when selecting "finish game anyway" from last-hole-warning page.

Refactor: now we loop through the players scores when clicking on last hole in the grid. That variable is passed on to the last-hole-warning page as a param, so it doesn't need to loop through again to get and output the "unplayed hole numbers".